### PR TITLE
Dev/dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ sankaku/sankaku/settings.py
 + `resources/images` ... ダウンロード画像管理用
 + `resources/images/***` ... 顔認識した画像の切取（`IMAGES_STORE_ANIME_FACE_DIR`で指定）
 + `resources/images/full` ... ダウンロードした元画像
-+ `resources/images/thumbs/***` ... サムネイル画像用
 + `resources/outputs` ... 収集データの出力先
 + `resources/storage` ... コンテナ内のデータ永続化用
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ make boot
 月刊ランキングページを解析する
 
 ```
-make crawl RUN_ARGS="ranking -o ranking.jl"
+make crawl RUN_ARGS="ranking -o ranking.csv"
 ```
 
 指定したTAGの画像を収集/解析する
@@ -39,14 +39,17 @@ make crawl RUN_ARGS="tag -a TAG=矢吹健太朗 -s IMAGES_STORE_ANIME_FACE_DIR=�
 make crawl RUN_ARGS="page -a URL=https://chan.sankakucomplex.com/ja/post/show/5597890"
 ```
 
-収集データをファイルに書き出す
+データセットを作成する
 
 ```
-# csvにデータを出力
+# DBデータをCSVに書き出す
 make mongo-export
 
-# csvにデータを元にデータセットを作成
-make dataset RUN_ARGS="--csv output_***.csv"
+# or scrapy -o ***.csvのファイルを使用する
+
+# CSVにデータを元にデータセットを作成
+# scrapyの`-o ***.csv`で出力したファイルも可（フィールド名がデータ箇所にある場合は削除すること）
+make dataset RUN_ARGS="--csv ***.csv"
 ```
 
 ----

--- a/misc/dataset.py
+++ b/misc/dataset.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 import json
 import math
 import os
@@ -29,6 +30,14 @@ def dataset_path(step='train'):
     else:
         path = os.path.join(work_dir, 'train')
     return path
+
+
+def json_decode(content):
+    try:
+        return json.loads(content)
+    except json.decoder.JSONDecodeError:
+        # single quote json data
+        return ast.literal_eval(content)
 
 
 def resize(path, img_size=64):
@@ -81,12 +90,12 @@ def process(csv_file):
         pbar.update(1)
 
         # image
-        image = json.loads(v['images'])
+        image = json_decode(v['images'])
         if len(image) < 1:
             continue
 
         # tag
-        tags = json.loads(v['tags'])
+        tags = json_decode(v['tags'])
         if FLAGS.category not in tags:
             continue
 

--- a/sankaku/sankaku/settings.py
+++ b/sankaku/sankaku/settings.py
@@ -109,15 +109,6 @@ FILES_EXPIRES = 120
 # 画像の有効期限
 IMAGES_EXPIRES = 30
 
-# 画像のサムネイルサイズ
-IMAGES_THUMBS = {
-    'medium': (200, 200),
-}
-
-# 画像のサムネイル対象サイズ（以上）
-IMAGES_MIN_HEIGHT = 110
-IMAGES_MIN_WIDTH = 110
-
 # アニメ顔認識用特徴データ
 CASCADE_ANIME_FACE_PATH = '/usr/src/app/resources/cascades/lbpcascade_animeface.xml'
 


### PR DESCRIPTION
+ 自動サムネイル処理の削除
+ データセット作成コマンドの修正

----

クロールデータの書き出し
```
make crawl RUN_ARGS="ranking -o ranking.csv"
```

or 

DBデータの書き出し
```
make mongo-export
#output_dir: /resources/outputs.
```

----

収集データからデータセットを作成する（例：キャラクター）

```
make dataset RUN_ARGS="--csv ***.csv --category character"
#output_dir: /resources/outputs
```

